### PR TITLE
Run APP4 CMIP6 conversion with payu

### DIFF
--- a/scripts/archive.sh
+++ b/scripts/archive.sh
@@ -6,6 +6,8 @@ set -a
 module purge
 module use /g/data/hh5/public/modules
 module use ~access/modules
+module load pbs
+module load parallel
 module load pythonlib/um2netcdf4/2.0
 
 # set the environment variables for ACCESS-Archiver
@@ -25,7 +27,7 @@ ncexists=false
 arch_grp=$PROJECT
 UMDIR=~access/umdir
 
-# setup dircetories
+# # setup dircetories
 rm -rf $here/tmp/$loc_exp
 mkdir -p $here/tmp/$loc_exp
 mkdir -p $arch_dir/$loc_exp/{history/atm/netCDF,restart/atm}
@@ -36,3 +38,67 @@ python -s -W ignore $here/subroutines/run_um2nc.py # convert UM files to netcdf
 $here/subroutines/cp_hist_payu.sh # copy over history
 $here/subroutines/cp_rest_payu.sh # copy over output files
 $here/subroutines/mppnccomb_check.sh # combine ocean output files
+
+#
+########################################
+#
+# set environment variables for APP4
+DATA_LOC=/g/data/tm70/kr4383/archive/access-esm/
+EXP_TO_PROCESS=esm-historical                # local name of experiment
+VERSION=ESM                                  # select one of: [CM2, ESM, OM2[-025]]
+                             # internal year to end CMORisation (inclusive)
+REFERENCE_YEAR=1850                          # reference date for time units (set as 'default' to use START_YEAR)
+CONTACT=access_csiro@csiro.au                # please insert your contact email
+# Please provide a short description of the experiment. For those created from the p73 archive, it's ok to just link to the Archive Wiki.
+EXP_DESCRIPTION="Pacemaker, Topical Atlantic, HadISST obs. see: https://confluence.csiro.au/display/ACCESS/ACCESS+Model+Output+Archive+%28p73%29+Wiki"
+
+# fragile way to set start and end years
+
+# find last created output folder - highest suffix number
+tmp=(archive/output*)
+output_folders=($(for l in ${tmp[@]}; do echo $l; done | sort))
+output_folder=${output_folders[-1]}
+
+# find the list of ice files for the most recent run
+tmp=(${output_folder}/ice/HISTORY/*)
+ice_files=($(for l in ${tmp[@]}; do echo $l; done | sort))
+
+# sort the files and extract the first and last year
+START_YEAR=$(echo ${ice_files[0]} | cut -d "." -f 2 | cut -d "-" -f 1)
+END_YEAR=$(echo ${ice_files[-1]} | cut -d "." -f 2 | cut -d "-" -f 1)
+
+echo "Start year: ${START_YEAR}"
+echo "End year: ${END_YEAR}"
+
+# Standard experiment details:
+#
+experiment_id=hist-control                   # standard experiment name (e.g. piControl)
+activity_id=PacemakerMIP                     # activity/MIP name (e.g. CMIP)
+realization_index=1                          # "r1"[i1p1f1] (e.g. 1)
+initialization_index=1                       # [r1]"i1"[p1f1] (e.g. 1)
+physics_index=1                              # [r1i1]"p1"[f1] (e.g. 1)
+forcing_index=1                              # [r1i1p1]"f1" (e.g. 1)
+source_type=AOGCM                            # see input_files/custom_mode_cmor-tables/Tables/CMIP6_CV.json
+branch_time_in_child=0D0                     # specifies the difference between the time units base and the first internal year (e.g. 365D0)
+
+# Parent experiment details:
+# if parent=false, all parent fields are automatically set to "no parent". If true, defined values are used.
+#
+parent=true 
+parent_experiment_id=piControl               # experiment name of the parent (e.g. piControl-spinup)
+parent_activity_id=CMIP                      # activity/MIP name of the parent (e.g. CMIP)
+parent_time_units="days since 0950-01-01"    # time units of the parent (e.g. "days since 0001-01-01")
+branch_time_in_parent=0D0                    # internal time of the parent at which the branching occured (e.g. 0D0)
+parent_variant_label=r1i1p1f1                # variable label of the parent (e.g. r1i1p1f1)
+
+# Variables to CMORise: 
+# CMIP6 table/variable to process; default is 'all'. Or create a file listing variables to process (VAR_SUBSET[_LIST]).
+#
+DREQ=default                                 # default=input_files/dreq/cmvme_all_piControl_3_3.csv
+TABLE_TO_PROCESS=all                         # CMIP6 table to process. Default is 'all'
+VARIABLE_TO_PROCESS=all                      # CMIP6 variable to process. Default is 'all'
+SUBDAILY=false                               # subdaily selection options - select one of: [true, false, only]
+VAR_SUBSET=false                             # use a sub-set list of variables to process, as defined by 'VAR_SUBSET_LIST'
+VAR_SUBSET_LIST=input_files/var_subset_lists/var_subset_ACS.csv
+
+./scripts/run_app4.sh

--- a/scripts/run_app4.sh
+++ b/scripts/run_app4.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+set -a 
+
+# Additional NCI information:
+# OUTPUT_LOC defines directory for all generated data (CMORISED files & logs)
+#
+OUTPUT_LOC=/scratch/$PROJECT/$USER/APP4_output 
+PROJECT=$PROJECT                             # NCI project to charge compute; $PROJECT = your default project
+QUEUE=hugemem                                # NCI queue to use; hugemem is recommended
+MEM_PER_CPU=24                               # memory (GB) per CPU (recommended: 24 for daily/monthly; 48 for subdaily) 
+ADDPROJS=( p66 )
+#
+#
+#
+#
+#
+#
+
+# Set up environment
+MODE=custom
+APP_DIR=/g/data/tm70/kr4383/APP4
+HISTORY_DATA=$DATA_LOC/$EXP_TO_PROCESS/history
+source $APP_DIR/subroutines/setup_env.sh
+# Cleanup output_files
+$APP_DIR/subroutines/cleanup.sh $OUT_DIR
+
+# Create json file which contains metadata info
+python $APP_DIR/subroutines/custom_json_editor.py
+
+# Create variable maps
+python $APP_DIR/subroutines/dreq_mapping.py --multi
+
+# Create database
+python $APP_DIR/subroutines/database_manager.py
+
+
+################################################################
+# CREATE JOB
+################################################################
+echo -e '\ncreating job...'
+
+for addproj in ${ADDPROJS[@]}; do
+  addstore="${addstore}+scratch/${addproj}+gdata/${addproj}"
+done
+#
+NUM_ROWS=$( cat $OUT_DIR/database_count.txt )
+if (($NUM_ROWS <= 24)); then
+  NUM_CPUS=$NUM_ROWS
+else
+  NUM_CPUS=24
+fi
+NUM_MEM=$(echo "${NUM_CPUS} * ${MEM_PER_CPU}" | bc)
+if ((${NUM_MEM} >= 1470)); then
+  NUM_MEM=1470
+fi
+#
+#NUM_CPUS=48
+#NUM_MEM=1470
+echo "number of files to create: ${NUM_ROWS}"
+echo "number of cpus to to be used: ${NUM_CPUS}"
+echo "total amount of memory to be used: ${NUM_MEM}Gb"
+
+JOB_OUTPUT=./job_output.OU
+
+cat << EOF > $APP_JOB
+#!/bin/bash
+#PBS -P $PROJECT
+#PBS -q $QUEUE
+#PBS -l storage=scratch/$PROJECT+gdata/$PROJECT+gdata/hh5+gdata/access${addstore}
+#PBS -l ncpus=${NUM_CPUS},walltime=1:00:00,mem=${NUM_MEM}Gb,wd
+#PBS -j oe
+#PBS -N custom_app4_${EXP_TO_PROCESS}
+module purge
+set -a
+# pre
+EXP_TO_PROCESS=${EXP_TO_PROCESS}
+OUTPUT_LOC=$OUTPUT_LOC
+MODE=$MODE
+CONTACT=$CONTACT
+CDAT_ANONYMOUS_LOG=no
+APP_DIR=/g/data/tm70/kr4383/APP4
+source $APP_DIR/subroutines/setup_env.sh
+# main
+python $APP_DIR/subroutines/app_wrapper.py
+# post
+python ${OUT_DIR}/database_updater.py
+sort ${SUCCESS_LISTS}/${EXP_TO_PROCESS}_success.csv \
+    > ${SUCCESS_LISTS}/${EXP_TO_PROCESS}_success_sorted.csv
+mv ${SUCCESS_LISTS}/${EXP_TO_PROCESS}_success_sorted.csv \
+    ${SUCCESS_LISTS}/${EXP_TO_PROCESS}_success.csv
+sort ${SUCCESS_LISTS}/${EXP_TO_PROCESS}_failed.csv \
+    > ${SUCCESS_LISTS}/${EXP_TO_PROCESS}_failed_sorted.csv 2>/dev/null
+mv ${SUCCESS_LISTS}/${EXP_TO_PROCESS}_failed_sorted.csv \
+    ${SUCCESS_LISTS}/${EXP_TO_PROCESS}_failed.csv
+echo "APP completed for exp ${EXP_TO_PROCESS}."
+EOF
+
+/bin/chmod 775 ${APP_JOB}
+echo "app job script: ${APP_JOB}"
+qsub ${APP_JOB}


### PR DESCRIPTION
This PR runs APP4 after each run on the files produced by that run. It never CMORises data of previous runs. The CMORised data from each run are in seperate files.

A few potential issues:

- It figures out the year range of the run based on the file names in the `output[0-9][0-9][0-9]` folder with the highest suffix. This seems slightly fragile and there's probably a better way.
- APP4 is run in a seperate PBS job after `payu` is finished. This job is orphaned from the `payu` runs but this doesn't seem to cause any issues, and it allows `payu` to start the next run while the previous run is being CMORised.

Also @MartinDix all the experiment details are currently wrong! I wasn't sure what to put so I copied over some values from another experiment so please correct me here.